### PR TITLE
Address punctuation in many languages

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -6,11 +6,10 @@ import json
 import os
 import random
 import re
-import string
 import sys
 from typing import Any, Dict, List, Set, Tuple
+import unicodedata
 
-table = str.maketrans(dict.fromkeys(string.punctuation))
 
 FIELDSEP = "|"
 
@@ -47,6 +46,16 @@ def read_trans_prompts(lines: List[str]) -> List[Tuple[str,str]]:
                 first = False
 
     return ids_prompts
+
+
+def strip_punctuation(text: str) -> str:
+    """
+    Remove punctuations of several languages, including Japanese.
+    """
+    return "".join(
+        itertools.filterfalse(lambda x: unicodedata.category(x).startswith("P"), text)
+    )
+
 
 def read_transfile(lines: List[str], strip_punc=True, weighted=False) -> Dict[str, Dict[str, float]]:
     """
@@ -85,7 +94,7 @@ def read_transfile(lines: List[str], strip_punc=True, weighted=False) -> Dict[st
                     weight = 1
 
                 if strip_punc:
-                    text = text.translate(table)
+                    text = strip_punctuation(text)
 
                 options[text] = float(weight)
 


### PR DESCRIPTION
Including Japanese!

**Why?** Not every language's punctuation is in `string.punctuation`, including languages in this task. Here's a test case illustrating why this is necessary:

```python
from itertools import filterfalse
import string
import unicodedata


# Test this string. Note that the second question mark is Japanese, as is the final full stop.
text = "Hello, how are you? Oh, me？ I am well。"


# Current way
table = str.maketrans(dict.fromkeys(string.punctuation))
print(text.translate(table))


# Proposed way
def strip_punctuation(text: str) -> str:
    return "".join(
        filterfalse(lambda x: unicodedata.category(x).startswith("P"), text)
    )


print(strip_punctuation(text))
```

Output:
```
Hello how are you Oh me？ I am well。
Hello how are you Oh me I am well
```

The proposed way eliminates the Japanese punctuation marks (and would also work if you reran the task in future years, with new languages).

**How?** It uses the [Unicode character categories][unicode] of the characters. Any category starting with a P is punctuation; the characters that would be excluded are a strict superset of the characters that are excluded in `master`'s version.


[unicode]: https://www.fileformat.info/info/unicode/category/index.htm