### PR TITLE
Added Japanese punctuation

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ import string
 import sys
 from typing import Any, Dict, List, Set, Tuple
 
-table = str.maketrans(dict.fromkeys(string.punctuation))
+table = str.maketrans(dict.fromkeys(string.punctuation + "。？、"))
 
 FIELDSEP = "|"
 


### PR DESCRIPTION
Japanese punctuation is not removed prior to evaluation. This adds Japanese punctuation found in the Duolingo gold data to the set of punctuation marks so that it is removed.

@aryamccarthy suggested it would be better to do this with Unicode character classes. I agree, but this was easier, and AFAICS, this covers the use case at hand.